### PR TITLE
RavenDB-26423 HNSW vector search: L2-norm cache, FMA DotProduct

### DIFF
--- a/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
@@ -306,7 +306,7 @@ public partial class IndexWriter
 
             var vectorWriter = field.GetVectorIndexer(_parent._transaction.LowLevelTransaction, value.Length, random);
             var vectorHash = vectorWriter.Register((long)_entryId, value);
-            
+
             //We're storing the vector hash for removal purposes
             RegisterTerm(field, vectorHash.ToSpan(), StoredFieldType.Raw);
         }

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -133,6 +133,7 @@ public struct VectorSearchMatch : IQueryMatch
         
         
         var searchState = _indexSearcher.GetOrCreateVectorSearchState(fieldName);
+
         _vectorSearchRetriever = _isExact switch
         {
             _ when _scanningQuery => Hnsw.ExactNearest(searchState, _numberOfCandidates, vector, _minimumMatch, hasFilterMatch: false, nodesIdsToScan),

--- a/src/Corax/Utils/VectorValue.cs
+++ b/src/Corax/Utils/VectorValue.cs
@@ -41,7 +41,7 @@ public struct VectorValue : IDisposable
     }
 
     public void OverrideLength(int len) => _length = len;
-    
+
     public void Dispose()
     {
         _memoryScope?.Dispose();

--- a/src/Sparrow.Server/Tensors/Functions.cs
+++ b/src/Sparrow.Server/Tensors/Functions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Net;
 using System.Numerics;
 using System.Numerics.Tensors;
 using System.Runtime.CompilerServices;
@@ -27,6 +26,39 @@ namespace Sparrow.Server.Tensors
             where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
         {
             return TResult.One - CosineSimilarity<T, TResult>(a, b);
+        }
+
+        /// <summary>
+        /// Returns Σ aᵢ·bᵢ for two equal-length f32 spans. On AVX2+FMA / AVX-512 the work is
+        /// issued as multiple independent FMA chains using <see cref="Arithmetics.MultiplyAddEstimate(Vector512{float}, Vector512{float}, Vector512{float})"/>.
+        /// On AArch64/NEON the NEON-shaped kernel is used. On 32-bit hosts or for inputs shorter
+        /// than one Vector512 the call is forwarded to <see cref="TensorPrimitives.Dot(ReadOnlySpan{float}, ReadOnlySpan{float})"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float DotProduct(ReadOnlySpan<float> a, ReadOnlySpan<float> b)
+        {
+            Debug.Assert(a.Length == b.Length, "a.Length == b.Length");
+
+            if (PlatformDetails.Is32Bits || a.Length < Vector512<float>.Count)
+                return TensorPrimitives.Dot(a, b);
+
+            if (AdvInstructionSet.IsAcceleratedVector256)
+            {
+                return (float)Vectorized512.DotProductInternalX64(
+                    ref MemoryMarshal.GetReference(a),
+                    ref MemoryMarshal.GetReference(b),
+                    (nuint)a.Length);
+            }
+
+            if (AdvInstructionSet.Arm.IsSupported)
+            {
+                return (float)Vectorized512.DotProductInternalNeon(
+                    ref MemoryMarshal.GetReference(a),
+                    ref MemoryMarshal.GetReference(b),
+                    (nuint)a.Length);
+            }
+
+            return TensorPrimitives.Dot(a, b);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -407,6 +439,121 @@ namespace Sparrow.Server.Tensors
                 double b2Reciprocal = rsqrts.ToScalar(); // lane 0
                 double a2Reciprocal = Sse2.UnpackHigh(rsqrts, rsqrts).ToScalar(); // lane 1
                 return  ab * a2Reciprocal * b2Reciprocal;
+            }
+
+            /// <summary>
+            /// Σ aᵢ·bᵢ for an f32 span on x64 with AVX2+FMA or AVX-512. Two Vector512 accumulators
+            /// are updated per loop iteration; on AVX2-only hardware the JIT lowers each Vector512
+            /// FMA to a pair of Vector256 FMAs, yielding 4 independent ymm FMA chains that saturate
+            /// the FMA issue ports. The two-accumulator shape keeps total ymm pressure at 4, inside
+            /// the 16-register budget. The trailing partial vector is masked via
+            /// <see cref="MoveMaskTable"/> so no scalar tail loop is required.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal static double DotProductInternalX64(ref float aRef, ref float bRef, nuint size)
+            {
+                Vector512<float> ab0 = Vector512<float>.Zero;
+                Vector512<float> ab1 = Vector512<float>.Zero;
+
+                nuint step = (nuint)Vector512<float>.Count;
+                nuint oneVectorFromEnd = size - step;
+                nuint twoFromEnd = size >= 2 * step ? size - 2 * step : 0;
+                nuint i = 0;
+
+            Loop2:
+                // Two independent FMA chains per iteration. Enter only when the span is wide
+                // enough to load both vectors; the single-vector body below drains the rest.
+                if (size >= 2 * step && i <= twoFromEnd)
+                {
+                    var a0 = Vector512.LoadUnsafe(ref aRef, i);
+                    var b0 = Vector512.LoadUnsafe(ref bRef, i);
+                    var a1 = Vector512.LoadUnsafe(ref aRef, i + step);
+                    var b1 = Vector512.LoadUnsafe(ref bRef, i + step);
+
+                    ab0 = Arithmetics.MultiplyAddEstimate(a0, b0, ab0);
+                    ab1 = Arithmetics.MultiplyAddEstimate(a1, b1, ab1);
+
+                    i += 2 * step;
+                    goto Loop2;
+                }
+
+                if (i <= oneVectorFromEnd)
+                {
+                    var aV = Vector512.LoadUnsafe(ref aRef, i);
+                    var bV = Vector512.LoadUnsafe(ref bRef, i);
+                    ab0 = Arithmetics.MultiplyAddEstimate(aV, bV, ab0);
+                    i += step;
+                }
+
+                if (i != size)
+                {
+                    nuint offset = size - i;
+                    Debug.Assert((int)offset * sizeof(float) + Vector512<byte>.Count <= MoveMaskTable.Length);
+
+                    var mask = Vector512.LoadUnsafe<float>(
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, float>(MoveMaskTable)), offset);
+
+                    var aTail = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref aRef, oneVectorFromEnd), mask);
+                    var bTail = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref bRef, oneVectorFromEnd), mask);
+                    ab0 = Arithmetics.MultiplyAddEstimate(aTail, bTail, ab0);
+                }
+
+                return (double)Vector512.Sum(ab0 + ab1);
+            }
+
+            /// <summary>
+            /// Σ aᵢ·bᵢ for an f32 span on AArch64/NEON. Two Vector512 accumulators are updated per
+            /// loop iteration; the JIT lowers each Vector512 op onto four 128-bit NEON vectors,
+            /// yielding independent FMA chains. Tail bytes are masked via <see cref="MoveMaskTable"/>.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal static double DotProductInternalNeon(ref float aRef, ref float bRef, nuint size)
+            {
+                Vector512<float> ab0 = Vector512<float>.Zero;
+                Vector512<float> ab1 = Vector512<float>.Zero;
+
+                nuint step = (nuint)Vector512<float>.Count;
+                nuint oneVectorFromEnd = size - step;
+                nuint twoFromEnd = size >= 2 * step ? size - 2 * step : 0;
+                nuint i = 0;
+
+            Loop2:
+                // Two independent FMA chains per iteration. Enter only when the span is wide
+                // enough to load both vectors; the single-vector body below drains the rest.
+                if (size >= 2 * step && i <= twoFromEnd)
+                {
+                    var a0 = Vector512.LoadUnsafe(ref aRef, i);
+                    var b0 = Vector512.LoadUnsafe(ref bRef, i);
+                    var a1 = Vector512.LoadUnsafe(ref aRef, i + step);
+                    var b1 = Vector512.LoadUnsafe(ref bRef, i + step);
+
+                    ab0 = Arithmetics.MultiplyAddEstimate(a0, b0, ab0);
+                    ab1 = Arithmetics.MultiplyAddEstimate(a1, b1, ab1);
+
+                    i += 2 * step;
+                    goto Loop2;
+                }
+
+                if (i <= oneVectorFromEnd)
+                {
+                    var aV = Vector512.LoadUnsafe(ref aRef, i);
+                    var bV = Vector512.LoadUnsafe(ref bRef, i);
+                    ab0 = Arithmetics.MultiplyAddEstimate(aV, bV, ab0);
+                    i += step;
+                }
+
+                if (i != size)
+                {
+                    nuint offset = size - i;
+                    var mask = Vector512.LoadUnsafe<float>(
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, float>(MoveMaskTable)), offset);
+
+                    var aTail = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref aRef, oneVectorFromEnd), mask);
+                    var bTail = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref bRef, oneVectorFromEnd), mask);
+                    ab0 = Arithmetics.MultiplyAddEstimate(aTail, bTail, ab0);
+                }
+
+                return (double)Vector512.Sum(ab0 + ab1);
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Voron/Constants.cs
+++ b/src/Voron/Constants.cs
@@ -102,11 +102,18 @@ namespace Voron.Global
                 public const long VectorContainerInternalIndexer = 1;
             }
 
-            internal static class HnswVersion
+            public static class HnswVersion
             {
                 public const ushort InitialVersion = 7_000;
-                
-                public const ushort CurrentVersion = InitialVersion;
+
+                // Singles vectors store a trailing float L2 norm alongside the payload,
+                // mirroring the (sbyte[dims] + float magnitude) layout already used by Int8.
+                // The kernel reads the cached norm instead of recomputing Σ x_i² on every
+                // distance call. Indexes created before this version keep the legacy
+                // float[dims] layout and are served by the norm-recomputing kernel.
+                public const ushort SinglesWithL2Norm = 7_001;
+
+                public const ushort CurrentVersion = SinglesWithL2Norm;
             }
         }
         

--- a/src/Voron/Data/Graphs/Hnsw.NormalizedLayout.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NormalizedLayout.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Numerics.Tensors;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Sparrow.Server;
+
+namespace Voron.Data.Graphs;
+
+public partial class Hnsw
+{
+    /// <summary>
+    /// Shared storage layout for HNSW tensors that carry a scalar magnitude: <c>T[dims]</c>
+    /// followed by a trailing <c>float</c>. Used by <see cref="SimilarityMethod.CosineSimilaritySingles"/>
+    /// (unit vector + L2 norm, starting at <see cref="Global.Constants.Graphs.HnswVersion.SinglesWithL2Norm"/>)
+    /// and <see cref="SimilarityMethod.CosineSimilarityI8"/> (int8-quantized vector + quantization
+    /// scale). Hamming/Binary does not use this layout.
+    /// </summary>
+    public const int MagnitudeSizeInBytes = sizeof(float);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int TensorSizeBytes<T>(int dimensions) where T : unmanaged
+        => dimensions * Unsafe.SizeOf<T>() + MagnitudeSizeInBytes;
+
+    /// <summary>
+    /// Writes <paramref name="vector"/> followed by <paramref name="magnitude"/> into
+    /// <paramref name="destination"/>. The destination must be sized exactly
+    /// <see cref="TensorSizeBytes{T}"/>.
+    /// </summary>
+    public static void WriteTensor<T>(ReadOnlySpan<T> vector, float magnitude, Span<byte> destination) where T : unmanaged
+    {
+        int expected = TensorSizeBytes<T>(vector.Length);
+        if (destination.Length != expected)
+            throw new ArgumentException($"Destination must be {expected} bytes, got {destination.Length}.", nameof(destination));
+
+        var vecBytes = MemoryMarshal.AsBytes(vector);
+        vecBytes.CopyTo(destination);
+        Unsafe.WriteUnaligned(ref destination[vecBytes.Length], magnitude);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float ReadTensorMagnitude(ReadOnlySpan<byte> atRest)
+        => Unsafe.ReadUnaligned<float>(
+            ref MemoryMarshal.GetReference(atRest[^MagnitudeSizeInBytes..]));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ReadOnlySpan<T> ReadTensorVector<T>(ReadOnlySpan<byte> atRest) where T : unmanaged
+        => MemoryMarshal.Cast<byte, T>(atRest[..^MagnitudeSizeInBytes]);
+
+    /// <summary>
+    /// True when vectors for <paramref name="options"/> must be pre-normalized into the storage
+    /// layout before being handed to HNSW. Only the f32 cosine path needs this; Int8 and Hamming
+    /// keep their original shapes.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool VectorNormalizationRequired(in Options options) =>
+        options.SimilarityMethod == SimilarityMethod.CosineSimilaritySingles
+        && options.Version >= Global.Constants.Graphs.HnswVersion.SinglesWithL2Norm;
+
+    /// <summary>
+    /// Allocates a scope-owned buffer, normalizes <paramref name="vector"/> into it, and
+    /// rebinds <paramref name="vector"/> to the new buffer. Returns <c>false</c> without
+    /// allocating when no normalization is needed (similarity method that does not consume
+    /// the normalized layout, on-disk version that predates it, or input already in storage
+    /// form). Throws when the input is not a raw
+    /// float[dims] payload of the expected dimensionality.
+    /// </summary>
+    internal static bool TryNormalizeQueryVector(in Options options, ByteStringContext allocator, ref Memory<byte> vector,
+        out ByteStringContext<ByteStringMemoryCache>.InternalScope scope)
+    {
+        scope = default;
+        if (VectorNormalizationRequired(options) == false)
+            return false;
+        if (vector.Length == options.VectorSizeBytes)
+            return false;
+
+        var floats = MemoryMarshal.Cast<byte, float>(vector.Span);
+        var expected = TensorSizeBytes<float>(floats.Length);
+        if (expected != options.VectorSizeBytes)
+            throw new ArgumentException($"Query vector has {vector.Length} bytes which does not match the expected normalized size ({options.VectorSizeBytes}) for this index.");
+
+        scope = AllocateNormalizedQueryVector(allocator, floats, expected, out vector);
+        return true;
+    }
+
+    private static unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope AllocateNormalizedQueryVector(
+        ByteStringContext allocator, ReadOnlySpan<float> floats, int expected, out Memory<byte> vector)
+    {
+        var scope = allocator.Allocate(expected, out ByteString buf);
+        WriteNormalizedTensor(floats, buf.ToSpan());
+        vector = new NormalizedQueryMemoryManager(buf.Ptr, expected).Memory;
+        return scope;
+    }
+
+    private sealed unsafe class NormalizedQueryMemoryManager : System.Buffers.MemoryManager<byte>
+    {
+        private readonly byte* _ptr;
+        private readonly int _length;
+
+        public NormalizedQueryMemoryManager(byte* ptr, int length)
+        {
+            _ptr = ptr;
+            _length = length;
+        }
+
+        public override Span<byte> GetSpan() => new(_ptr, _length);
+        public override System.Buffers.MemoryHandle Pin(int elementIndex = 0) => new(_ptr + elementIndex);
+        public override void Unpin() { }
+        protected override void Dispose(bool disposing) { }
+    }
+
+    /// <summary>
+    /// Normalizes <paramref name="raw"/> in place into <paramref name="destination"/>
+    /// (unit floats + trailing L2 norm). Returns the original L2 norm; zero-norm input
+    /// is preserved verbatim with magnitude 0 and the distance kernel must branch on it.
+    /// </summary>
+    public static float WriteNormalizedTensor(ReadOnlySpan<float> raw, Span<byte> destination)
+    {
+        int expected = TensorSizeBytes<float>(raw.Length);
+        if (destination.Length != expected)
+            throw new ArgumentException($"Destination must be {expected} bytes, got {destination.Length}.", nameof(destination));
+
+        var unit = MemoryMarshal.Cast<byte, float>(destination[..(raw.Length * sizeof(float))]);
+
+        float sumSq = TensorPrimitives.SumOfSquares(raw);
+        float magnitude = MathF.Sqrt(sumSq);
+        if (magnitude > 0f)
+            TensorPrimitives.Divide(raw, magnitude, unit);
+        else
+            raw.CopyTo(unit); // zero vector: preserve zeros; kernel must branch on magnitude == 0
+
+        Unsafe.WriteUnaligned(
+            ref destination[raw.Length * sizeof(float)],
+            magnitude);
+
+        return magnitude;
+    }
+}

--- a/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
+++ b/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
@@ -49,7 +49,7 @@ public partial class Hnsw
         // Both operands are unit vectors here, so cosine distance collapses to 1 - a·b.
         var aUnit = ReadTensorVector<float>(a);
         var bUnit = ReadTensorVector<float>(b);
-        return 1f - TensorPrimitives.Dot(aUnit, bUnit);
+        return 1f - Sparrow.Server.Tensors.Functions.DotProduct(aUnit, bUnit);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
+++ b/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
@@ -26,17 +26,41 @@ public partial class Hnsw
         return Functions.CosineDistance(aSingles, bSingles);
     }
 
+    /// <summary>
+    /// Distance kernel for the <c>SinglesWithL2Norm</c> on-disk layout: both operands
+    /// are pre-normalized unit vectors with the original L2 norm stored in the trailing
+    /// <see cref="MagnitudeSizeInBytes"/> bytes of the buffer. For unit-norm inputs
+    /// <c>cosDistance(a,b) = 1 - a·b</c>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static float CosineDistanceSinglesNormalized(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
+    {
+        Debug.Assert(a.Length == b.Length, "a.Length == b.Length");
+
+        // Degenerate inputs: both zero-norm -> NaN (undefined direction on both sides);
+        // exactly one zero-norm -> similarity 0 (distance 1).
+        var aNorm = ReadTensorMagnitude(a);
+        var bNorm = ReadTensorMagnitude(b);
+        if (aNorm == 0f && bNorm == 0f)
+            return float.NaN;
+        if (aNorm == 0f || bNorm == 0f)
+            return 1f;
+
+        // Both operands are unit vectors here, so cosine distance collapses to 1 - a·b.
+        var aUnit = ReadTensorVector<float>(a);
+        var bUnit = ReadTensorVector<float>(b);
+        return 1f - TensorPrimitives.Dot(aUnit, bUnit);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static float CosineDistanceI8(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
     {
         Debug.Assert(a.Length == b.Length, "a.Length == b.Length");
-        var vectorLength = a.Length - sizeof(float);
 
-        var aRef = MemoryMarshal.Cast<byte, sbyte>(a[..vectorLength]);
-        var bRef = MemoryMarshal.Cast<byte, sbyte>(b[..vectorLength]);
-
-        var aMag = Unsafe.ReadUnaligned<float>(ref MemoryMarshal.GetReference(a[vectorLength..]));
-        var bMag = Unsafe.ReadUnaligned<float>(ref MemoryMarshal.GetReference(b[vectorLength..]));
+        var aRef = ReadTensorVector<sbyte>(a);
+        var bRef = ReadTensorVector<sbyte>(b);
+        var aMag = ReadTensorMagnitude(a);
+        var bMag = ReadTensorMagnitude(b);
 
         return Functions.CosineDistance(aRef, aMag, bRef, bMag);
     }

--- a/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
+++ b/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
@@ -31,6 +31,10 @@ public partial class Hnsw
         private readonly IHnswSearcher _vectorsSearcher;
         private readonly Memory<byte> _vector;
         private IEnumerator<bool> _resultsEnumerator;
+        // When the searchState-based entry points allocate a normalized copy of the query
+        // vector they hand the scope here so Dispose releases it alongside the retriever's
+        // other per-query state.
+        private Sparrow.Server.ByteStringContext<Sparrow.Server.ByteStringMemoryCache>.InternalScope? _queryVectorScope;
 
         public SimilarityMethod? SimilarityMethod => _searchState?.Options.SimilarityMethod;
         
@@ -45,12 +49,13 @@ public partial class Hnsw
         public long CandidatesProcessed => _vectorsSearcher?.CandidatesProcessed ?? 0;
         
         public VectorSearchRetriever(SearchState searchState, IHnswSearcher vectorsSearcher, Memory<byte> vector, float minimumSimilarity,
-            bool ownsSearchState = true)
+            bool ownsSearchState = true, Sparrow.Server.ByteStringContext<Sparrow.Server.ByteStringMemoryCache>.InternalScope? queryVectorScope = null)
         {
             _searchState = searchState;
             _ownsSearchState = ownsSearchState;
             _vectorsSearcher = vectorsSearcher;
             _vector = vector;
+            _queryVectorScope = queryVectorScope;
             _postingListResults = new(_searchState.Llt.Allocator);
             _pforDecoder = new(searchState.Llt.Allocator);
             _maximumDistance = searchState.MinimumSimilarityToDistance(minimumSimilarity);
@@ -314,6 +319,7 @@ public partial class Hnsw
             _pforDecoder.Dispose();
             _resultsEnumerator?.Dispose();
             _vectorsSearcher?.Dispose();
+            _queryVectorScope?.Dispose();
             if (_ownsSearchState)
                 _searchState.Dispose();
         }

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -11,6 +11,7 @@ using Sparrow.Binary;
 using Sparrow.Compression;
 using Sparrow.Platform;
 using Sparrow.Server;
+using Sparrow.Server.Tensors;
 using Sparrow.Server.Utils;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
@@ -53,6 +54,10 @@ public unsafe partial class Hnsw
             _ => throw new InvalidOperationException($"Unexpected value of {nameof(VectorEmbeddingType)}: {embeddingType}")
         };
 
+        // VectorEmbeddingType.Single is stored in the NormalizedTensor layout: unit vector followed by a trailing float L2 norm. Callers pass the raw payload size (dims * sizeof(float)); the trailing-norm bytes are added here so callers do not need to know about the layout.
+        if (embeddingType == VectorEmbeddingType.Single)
+            vectorSizeBytes += MagnitudeSizeInBytes;
+
         var options = new Options
         {
             Version = Constants.Graphs.HnswVersion.CurrentVersion,
@@ -67,6 +72,27 @@ public unsafe partial class Hnsw
         {
             Unsafe.Write(output, options);
         }
+    }
+
+    /// <summary>
+    /// Returns the distance kernel to use for a given HNSW <see cref="Options"/>. For
+    /// <see cref="SimilarityMethod.CosineSimilaritySingles"/> the kernel depends on the on-disk
+    /// version: at or above <see cref="Constants.Graphs.HnswVersion.SinglesWithL2Norm"/> the
+    /// operands are pre-normalized (NormalizedTensor layout) and the dot-only kernel applies;
+    /// below that version the operands are raw vectors and norms are recomputed per call.
+    /// </summary>
+    internal static delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> GetDistanceKernel(in Options options)
+    {
+        return options.SimilarityMethod switch
+        {
+            SimilarityMethod.CosineSimilaritySingles =>
+                options.Version >= Constants.Graphs.HnswVersion.SinglesWithL2Norm
+                    ? &CosineDistanceSinglesNormalized
+                    : &CosineDistanceSingles,
+            SimilarityMethod.CosineSimilarityI8 => &CosineDistanceI8,
+            SimilarityMethod.HammingDistance => &HammingDistance,
+            _ => throw new ArgumentOutOfRangeException(nameof(options.SimilarityMethod), options.SimilarityMethod, null)
+        };
     }
 
     private static ContainerId ReadGlobalVectorsContainerId(LowLevelTransaction llt)
@@ -110,6 +136,7 @@ public unsafe partial class Hnsw
         public readonly delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> SimilarityCalc;
         public readonly bool IsEmpty;
         private readonly HnswIndexCache _nodeCache;
+        private ByteStringContext<ByteStringMemoryCache>.InternalScope? _queryNormalizationScope;
 
         public Span<Node> Nodes => _nodes.ToSpan();
         public Tree Tree => _tree;
@@ -136,6 +163,14 @@ public unsafe partial class Hnsw
         {
         }
 
+        public SearchState(LowLevelTransaction llt, Slice name, ref Memory<byte> queryVector) : this(llt, name, null)
+        {
+            if (IsEmpty)
+                return;
+            if (TryNormalizeQueryVector(Options, Llt.Allocator, ref queryVector, out var scope))
+                _queryNormalizationScope = scope;
+        }
+
         public SearchState(LowLevelTransaction llt, Slice name, HnswIndexCache nodeCache)
         {
             Llt = llt;
@@ -158,13 +193,7 @@ public unsafe partial class Hnsw
             {
                 var options = _tree.DirectRead(OptionsSlice);
                 Options = Unsafe.Read<Options>(options);
-                SimilarityCalc = Options.SimilarityMethod switch
-                {
-                    SimilarityMethod.CosineSimilaritySingles => &CosineDistanceSingles,
-                    SimilarityMethod.CosineSimilarityI8 => &CosineDistanceI8,
-                    SimilarityMethod.HammingDistance => &HammingDistance,
-                    _ => throw new ArgumentOutOfRangeException(nameof(Options.SimilarityMethod), Options.SimilarityMethod, null)
-                };
+                SimilarityCalc = GetDistanceKernel(Options);
             }
         }
 
@@ -246,6 +275,7 @@ public unsafe partial class Hnsw
         public void RegisterNodeLocation(long nodeId, long locationId) =>
             _nodeIdToLocations.Add(nodeId, locationId);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ref Node GetNodeByIndex(int index)
         {
             ref var n = ref _nodes[index];
@@ -294,10 +324,14 @@ public unsafe partial class Hnsw
         /// <see cref="LoadNodeIndexes"/> dictionary lookups are skipped entirely.
         /// May grow the nodes array — callers must re-fetch any outstanding node refs afterward.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ResolveEdgeIndexes(int nodeIndex, int level, ref NativeList<long> nodeIds, ref NativeList<int> indexes)
         {
             ref var node = ref GetNodeByIndex(nodeIndex);
 
+            // Fast path: the resolved indexes for this level are already cached on the node.
+            // The slow path (miss) is in a NoInlining helper so only this copy is inlined into
+            // callers inside the search loop.
             if (node.EdgesIndexesPerLevel.Count > level &&
                 node.EdgesIndexesPerLevel[level].Count == node.EdgesPerLevel[level].Count)
             {
@@ -305,6 +339,13 @@ public unsafe partial class Hnsw
                 return;
             }
 
+            ResolveEdgeIndexesSlow(nodeIndex, level, ref nodeIds, ref indexes);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ResolveEdgeIndexesSlow(int nodeIndex, int level, ref NativeList<long> nodeIds, ref NativeList<int> indexes)
+        {
+            ref var node = ref GetNodeByIndex(nodeIndex);
             nodeIds.ResetAndCopyFrom(Llt.Allocator, node.EdgesPerLevel[level].ToSpan());
             LoadNodeIndexes(ref nodeIds, ref indexes);
 
@@ -425,12 +466,23 @@ public unsafe partial class Hnsw
         }
 
         // Allows storing cached distance to the queried vector. Should be used only in the querying part!
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float QueryDistance(ReadOnlySpan<byte> vector, int toIdx, ref long vectorReadCounter)
         {
+            // Fast path: the distance for this (query vector, node) pair was already computed during
+            // the current traversal and is still valid (version equals _visitsCounter). The miss path
+            // — loading the stored vector and running SimilarityCalc — lives in a NoInlining helper so
+            // its register footprint does not leak into the search loop.
             ref var to = ref GetNodeByIndex(toIdx);
             if (to.QueryDistanceVersion == _queryVectorVersion)
                 return to.QueryDistanceValue;
 
+            return QueryDistanceMiss(vector, ref to, ref vectorReadCounter);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private float QueryDistanceMiss(ReadOnlySpan<byte> vector, ref Node to, ref long vectorReadCounter)
+        {
             Span<byte> v2 = to.GetVector(this);
             vectorReadCounter++;
             var distance = SimilarityCalc(vector, v2);
@@ -740,7 +792,13 @@ public unsafe partial class Hnsw
 
            _nodes.Dispose(Llt.Allocator);
 
+           if (_queryNormalizationScope is { } scope)
+           {
+               scope.Dispose();
+               _queryNormalizationScope = null;
+           }
        }
+
     }
 
     public partial class Registration : IDisposable
@@ -755,7 +813,13 @@ public unsafe partial class Hnsw
         private readonly ContainerId _globalVectorsContainerId;
         private PostingList _largePostingListSet;
 
+        // Lazy scratch used by Register to normalize raw-sized inputs in-place; one allocation per Registration.
+        private ByteStringContext<ByteStringMemoryCache>.InternalScope _normalizationScope;
+        private ByteString _normalizationBuffer;
+
         public int AmountOfModifiedVectorsInTransaction => _vectorHashCache.Count;
+
+        public Options Options => _searchState.Options;
 
         public Registration(LowLevelTransaction llt, Slice name, Random random = null)
         {
@@ -862,9 +926,9 @@ public unsafe partial class Hnsw
         {
             entryId = EntryIdToInternalEntryId(entryId);
             PortableExceptions.ThrowIfOnDebug<ArgumentOutOfRangeException>((entryId & Constants.Graphs.VectorId.EnsureIsSingleMask) != 0, "Entry ids must have the first two bits cleared, we are using those");
-            PortableExceptions.ThrowIf<ArgumentOutOfRangeException>(
-                vector.Length != _searchState.Options.VectorSizeBytes,
-                $"Vector size {vector.Length} does not match expected size: {_searchState.Options.VectorSizeBytes}");
+
+            if (vector.Length != _searchState.Options.VectorSizeBytes)
+                vector = NormalizeIntoScratch(vector);
 
             var hashBuffer = ComputeHashFor(vector);
             ref (ByteString Hash, int NodeIndex, NativeList<long> PostingList) postingList = ref CollectionsMarshal.GetValueRefOrAddDefault(_vectorHashCache, hashBuffer, out var exists);
@@ -957,6 +1021,22 @@ public unsafe partial class Hnsw
                 //container id | index    | marker
                 return new ContainerEntryId((long)containerId | (uint)(index << 1) | Constants.Graphs.VectorStorage.VectorContainerInternalIndexer);
             }
+        }
+
+        private ReadOnlySpan<byte> NormalizeIntoScratch(ReadOnlySpan<byte> vector)
+        {
+            var expected = _searchState.Options.VectorSizeBytes;
+            var floats = MemoryMarshal.Cast<byte, float>(vector);
+            PortableExceptions.ThrowIf<ArgumentOutOfRangeException>(
+                VectorNormalizationRequired(_searchState.Options) == false || TensorSizeBytes<float>(floats.Length) != expected,
+                $"Vector size {vector.Length} does not match expected size: {expected}");
+
+            if (_normalizationBuffer.HasValue == false)
+                _normalizationScope = _searchState.Llt.Allocator.Allocate(expected, out _normalizationBuffer);
+
+            var dst = _normalizationBuffer.ToSpan();
+            WriteNormalizedTensor(floats, dst);
+            return dst;
         }
 
         private ByteString ComputeHashFor(ReadOnlySpan<byte> vector)
@@ -1104,7 +1184,8 @@ public unsafe partial class Hnsw
 
         public void Dispose()
         {
-            //todo: we may wants to release the vector hash cache
+            if (_normalizationBuffer.HasValue)
+                _normalizationScope.Dispose();
         }
 
         private long UpdatePostingList(ContainerEntryId postingListId, in NativeList<long> modifications, FastPForEncoder pForEncoder, ref FastPForDecoder pForDecoder, ref ContextBoundNativeList<long> tempListBuffer)
@@ -1190,15 +1271,15 @@ public unsafe partial class Hnsw
     
     public static VectorSearchRetriever ExactNearest(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch, ContextBoundNativeList<long>? nodesToScan = null)
     {
-        var searchState = new SearchState(llt, name);
+        var searchState = new SearchState(llt, name, ref vector);
         var results = searchState.ExactSearch(vector, hasFilterMatch, numberOfCandidates, nodesToScan);
         return new VectorSearchRetriever(searchState,  results, vector, minimumSimilarity);
     }
 
     public static VectorSearchRetriever ApproximateFilteredNearest<TEnumerator>(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, TEnumerator nodesToProbe)
-     where TEnumerator : IEnumerator<long> 
+     where TEnumerator : IEnumerator<long>
     {
-        var searchState = new SearchState(llt, name);
+        var searchState = new SearchState(llt, name, ref vector);
         var startingPointsIndexes = new ContextBoundNativeList<int>(llt.Allocator);
         var candidates = new ContextBoundNativeList<int>(llt.Allocator);
         candidates.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
@@ -1215,7 +1296,7 @@ public unsafe partial class Hnsw
     
     public static VectorSearchRetriever ApproximateNearest(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch = false)
     {
-        var searchState = new SearchState(llt, name);
+        var searchState = new SearchState(llt, name, ref vector);
         var nearestNodesByLevel = new ContextBoundNativeList<int>(llt.Allocator);
         nearestNodesByLevel.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
 
@@ -1239,6 +1320,7 @@ public unsafe partial class Hnsw
     /// </summary>
     public static VectorSearchRetriever ApproximateNearest(SearchState searchState, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch = false)
     {
+        TryNormalizeQueryVector(searchState.Options, searchState.Llt.Allocator, ref vector, out var queryVectorScope);
         // Bind the per-node QueryDistance cache to this query vector before SearchNearestAcrossLevels
         // reads it. Without this, a shared SearchState reuses cached distances from a prior sub-query
         // and the upper-level descent latches onto the wrong starting point.
@@ -1248,14 +1330,14 @@ public unsafe partial class Hnsw
         nearestNodesByLevel.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
 
         if (searchState.Options.CountOfVectors == 0)
-            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false);
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
 
         searchState.SearchNearestAcrossLevels(vector.Span, -1, searchState.Options.MaxLevel, ref nearestNodesByLevel);
         var nearest = nearestNodesByLevel[0];
         nearestNodesByLevel.Clear();
         var nearestEdgesSearch = searchState.NearestSearch(nearest, vector, 0, numberOfCandidates, nearestNodesByLevel,
             SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists, hasFilterMatch);
-        return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity, ownsSearchState: false);
+        return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
     }
 
     /// <summary>
@@ -1264,9 +1346,10 @@ public unsafe partial class Hnsw
     /// </summary>
     public static VectorSearchRetriever ExactNearest(SearchState searchState, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch, ContextBoundNativeList<long>? nodesToScan = null)
     {
+        TryNormalizeQueryVector(searchState.Options, searchState.Llt.Allocator, ref vector, out var queryVectorScope);
         searchState.OnQueryVector(vector);
         var results = searchState.ExactSearch(vector, hasFilterMatch, numberOfCandidates, nodesToScan);
-        return new VectorSearchRetriever(searchState, results, vector, minimumSimilarity, ownsSearchState: false);
+        return new VectorSearchRetriever(searchState, results, vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
     }
 
     /// <summary>
@@ -1276,6 +1359,7 @@ public unsafe partial class Hnsw
     public static VectorSearchRetriever ApproximateFilteredNearest<TEnumerator>(SearchState searchState, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, TEnumerator nodesToProbe)
         where TEnumerator : IEnumerator<long>
     {
+        TryNormalizeQueryVector(searchState.Options, searchState.Llt.Allocator, ref vector, out var queryVectorScope);
         searchState.OnQueryVector(vector);
 
         var startingPointsIndexes = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
@@ -1283,13 +1367,13 @@ public unsafe partial class Hnsw
         candidates.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
 
         if (searchState.Options.CountOfVectors == 0)
-            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false);
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
 
         searchState.SearchFilteredNearest(ref startingPointsIndexes, nodesToProbe, numberOfCandidates, 16);
         candidates.Clear();
         var nearestEdgesSearch = searchState.NearestSearch(startingPointsIndexes, vector, 0, numberOfCandidates, candidates,
             SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists);
-        return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity, ownsSearchState: false);
+        return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
     }
 
     public static VectorSearchRetriever EmptySearch(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity)

--- a/src/Voron/Data/Graphs/HnswIndexCache.cs
+++ b/src/Voron/Data/Graphs/HnswIndexCache.cs
@@ -161,13 +161,7 @@ public sealed unsafe class HnswIndexCache : IDisposable
     private static int AlignUp(int v, int align) => (v + align - 1) & ~(align - 1);
 
     private static delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> ResolveSimilarityKernel(in Hnsw.Options options) =>
-        options.SimilarityMethod switch
-        {
-            Hnsw.SimilarityMethod.CosineSimilaritySingles => &Hnsw.CosineDistanceSingles,
-            Hnsw.SimilarityMethod.CosineSimilarityI8 => &Hnsw.CosineDistanceI8,
-            Hnsw.SimilarityMethod.HammingDistance => &Hnsw.HammingDistance,
-            _ => throw new ArgumentOutOfRangeException(nameof(options.SimilarityMethod), options.SimilarityMethod, null)
-        };
+        Hnsw.GetDistanceKernel(options);
 
     /// <summary>
     /// Conservative bytes-per-node estimate used to translate a node-count budget into a buffer

--- a/test/FastTests/Sparrow/TensorsTests.cs
+++ b/test/FastTests/Sparrow/TensorsTests.cs
@@ -549,5 +549,31 @@ namespace FastTests.Sparrow
                 Assert.NotEqual(Functions.HammingBitDistance<byte>(aSpan, bSpan), 0);
             }
         }
+
+        // DotProduct dispatches to a two-accumulator Vector512 kernel once size is large enough
+        // for a SIMD path. The boundary sizes — exactly one vector wide, and exactly two vectors
+        // wide — are the ones most likely to hit off-by-one conditions in the loop/tail guards.
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineData(16)]
+        [InlineData(17)]
+        [InlineData(31)]
+        [InlineData(32)]
+        [InlineData(33)]
+        [InlineData(63)]
+        [InlineData(128)]
+        public void DotProduct_MatchesTensorPrimitives_AtVector512Boundaries(int size)
+        {
+            var rng = new Random(size);
+            var a = new float[size];
+            var b = new float[size];
+            for (int i = 0; i < size; i++)
+            {
+                a[i] = (float)(rng.NextDouble() * 2 - 1);
+                b[i] = (float)(rng.NextDouble() * 2 - 1);
+            }
+            var actual = Functions.DotProduct(a, b);
+            var expected = TensorPrimitives.Dot<float>(a, b);
+            Assert.InRange(actual - expected, -1e-4f, 1e-4f);
+        }
     }
 }

--- a/test/FastTests/Voron/Graphs/BasicGraphs.cs
+++ b/test/FastTests/Voron/Graphs/BasicGraphs.cs
@@ -299,10 +299,14 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
             Assert.Equal(2, read);
             var v1Pos = matches.AsSpan().Slice(0, read).IndexOf(1L);
             Assert.True(int.IsPositive(v1Pos));
-            Assert.Equal(Hnsw.CosineDistanceSingles(v1.GetEmbedding(), vQ.GetEmbedding()), distances[v1Pos]);
+            // Indexed and queried vectors are stored in NormalizedTensor at-rest form; the distance
+            // kernel dots pre-normalized unit vectors, which is algebraically identical to
+            // CosineDistanceSingles but can differ in the last bit due to rounding order, so compare
+            // with a small relative tolerance.
+            Assert.Equal(Hnsw.CosineDistanceSingles(v1.GetEmbedding(), vQ.GetEmbedding()), distances[v1Pos], precision: 5);
             var v2Pos = matches.AsSpan().Slice(0, read).IndexOf(2L);
             Assert.True(int.IsPositive(v2Pos));
-            Assert.Equal(Hnsw.CosineDistanceSingles(v2.GetEmbedding(), vQ.GetEmbedding()), distances[v2Pos]);
+            Assert.Equal(Hnsw.CosineDistanceSingles(v2.GetEmbedding(), vQ.GetEmbedding()), distances[v2Pos], precision: 5);
         }
     }
     

--- a/test/FastTests/Voron/Graphs/HnswIndexCacheTests.cs
+++ b/test/FastTests/Voron/Graphs/HnswIndexCacheTests.cs
@@ -150,7 +150,8 @@ public unsafe class HnswIndexCacheTests(ITestOutputHelper output) : StorageTest(
         BuildGraph(treeName, vectorCount: 300, seed: 19);
 
         float[] query = RandomVector(new Random(99));
-        var queryBytes = MemoryMarshal.Cast<float, byte>(query).ToArray();
+        var queryBytes = new byte[Hnsw.TensorSizeBytes<float>(query.Length)];
+        Hnsw.WriteNormalizedTensor(query, queryBytes);
 
         using (var tx = Env.ReadTransaction())
         {
@@ -208,6 +209,7 @@ public unsafe class HnswIndexCacheTests(ITestOutputHelper output) : StorageTest(
         }
         tx.Commit();
     }
+
 
     private static float[] RandomVector(Random random)
     {

--- a/test/FastTests/Voron/Graphs/HnswTests/L2NormCaching.cs
+++ b/test/FastTests/Voron/Graphs/HnswTests/L2NormCaching.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Numerics.Tensors;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Graphs;
+using Xunit;
+using VectorEmbeddingType = Voron.Data.Graphs.VectorEmbeddingType;
+
+namespace FastTests.Voron.Graphs.HnswTests;
+
+public class L2NormCaching(ITestOutputHelper output) : StorageTest(output)
+{
+    [RavenTheory(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    [InlineData(128)]
+    [InlineData(384)]
+    [InlineData(768)]
+    [InlineData(1536)]
+    public void LegacyAndNormalizedKernelsAgree(int dims)
+    {
+        // For random f32 vectors, the legacy CosineDistanceSingles (which recomputes both norms
+        // per call) and the new CosineDistanceSinglesNormalized (which reads the trailing norm
+        // and dots pre-normalized unit vectors) must return the same distance up to rounding.
+        var rng = new Random(dims);
+        var a = RandomFloats(rng, dims, scale: 3.0f);
+        var b = RandomFloats(rng, dims, scale: 5.0f);
+
+        var legacy = global::Voron.Data.Graphs.Hnsw.CosineDistanceSingles(
+            MemoryMarshal.AsBytes(a.AsSpan()),
+            MemoryMarshal.AsBytes(b.AsSpan()));
+
+        var aAtRest = new byte[Hnsw.TensorSizeBytes<float>(dims)];
+        var bAtRest = new byte[Hnsw.TensorSizeBytes<float>(dims)];
+        Hnsw.WriteNormalizedTensor(a, aAtRest);
+        Hnsw.WriteNormalizedTensor(b, bAtRest);
+
+        var normalized = global::Voron.Data.Graphs.Hnsw.CosineDistanceSinglesNormalized(aAtRest, bAtRest);
+
+        // Allow a small absolute tolerance; the two kernels differ only in float rounding order.
+        Assert.InRange(normalized - legacy, -1e-5f, 1e-5f);
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void NormalizeRoundTrip()
+    {
+        var rng = new Random(42);
+        const int dims = 64;
+        var raw = RandomFloats(rng, dims, scale: 7.0f);
+        var expectedNorm = MathF.Sqrt(TensorPrimitives.SumOfSquares(raw));
+
+        var atRest = new byte[Hnsw.TensorSizeBytes<float>(dims)];
+        var returnedNorm = Hnsw.WriteNormalizedTensor(raw, atRest);
+
+        Assert.Equal(expectedNorm, returnedNorm, precision: 4);
+        Assert.Equal(expectedNorm, Hnsw.ReadTensorMagnitude(atRest), precision: 4);
+
+        var unit = Hnsw.ReadTensorVector<float>(atRest);
+        Assert.Equal(dims, unit.Length);
+
+        // Dividing by the norm should leave a unit vector.
+        var unitSumSq = TensorPrimitives.SumOfSquares(unit);
+        Assert.Equal(1.0, (double)unitSumSq, precision: 4);
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void ZeroNormAdversarial()
+    {
+        const int dims = 16;
+        var zero = new float[dims];
+        var nonZero = RandomFloats(new Random(1), dims, scale: 1.0f);
+
+        var zeroAtRest = new byte[Hnsw.TensorSizeBytes<float>(dims)];
+        var nonZeroAtRest = new byte[Hnsw.TensorSizeBytes<float>(dims)];
+        Hnsw.WriteNormalizedTensor(zero, zeroAtRest);
+        Hnsw.WriteNormalizedTensor(nonZero, nonZeroAtRest);
+
+        // Both operands zero: kernel returns NaN (matches the semantics of the recompute-norms
+        // path, which divides by zero and produces NaN).
+        var bothZero = global::Voron.Data.Graphs.Hnsw.CosineDistanceSinglesNormalized(zeroAtRest, zeroAtRest);
+        Assert.True(float.IsNaN(bothZero));
+
+        // Exactly one operand zero: kernel returns 1f (distance = 1, similarity = 0). The spec
+        // does not prescribe more than "not NaN" for this case; 1f is the documented contract.
+        var mixedA = global::Voron.Data.Graphs.Hnsw.CosineDistanceSinglesNormalized(zeroAtRest, nonZeroAtRest);
+        var mixedB = global::Voron.Data.Graphs.Hnsw.CosineDistanceSinglesNormalized(nonZeroAtRest, zeroAtRest);
+        Assert.False(float.IsNaN(mixedA));
+        Assert.False(float.IsNaN(mixedB));
+        Assert.Equal(1f, mixedA);
+        Assert.Equal(1f, mixedB);
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void EndToEndHnswSearchReturnsCorrectNearestNeighbour()
+    {
+        using var _ = Slice.From(Allocator, "l2norm-e2e", out var treeName);
+        const int dims = 32;
+        var sizeBytes = dims * sizeof(float);
+
+        // Hand-crafted vectors chosen so vector #5 is clearly closest to the query.
+        var v1 = FilledVector(dims, 0.1f);
+        var v2 = FilledVector(dims, 0.5f);
+        var v3 = FilledVector(dims, -0.2f);
+        var v4 = FilledVector(dims, 1.5f);
+        var v5 = FilledVector(dims, 2.0f);
+
+        var query = FilledVector(dims, 1.95f); // closest to v5 by cosine similarity
+
+        using (var tx = Env.WriteTransaction())
+        {
+            global::Voron.Data.Graphs.Hnsw.Create(tx.LowLevelTransaction, treeName, sizeBytes, 8, 16, VectorEmbeddingType.Single);
+            using (var registration = global::Voron.Data.Graphs.Hnsw.RegistrationFor(tx.LowLevelTransaction, treeName, new Random(7)))
+            {
+                registration.Register(1, MemoryMarshal.Cast<float, byte>(v1));
+                registration.Register(2, MemoryMarshal.Cast<float, byte>(v2));
+                registration.Register(3, MemoryMarshal.Cast<float, byte>(v3));
+                registration.Register(4, MemoryMarshal.Cast<float, byte>(v4));
+                registration.Register(5, MemoryMarshal.Cast<float, byte>(v5));
+                registration.Commit(CancellationToken.None);
+            }
+            tx.Commit();
+        }
+
+        using (var tx = Env.ReadTransaction())
+        {
+            var queryBytes = MemoryMarshal.AsBytes(query.AsSpan()).ToArray();
+            using var retriever = global::Voron.Data.Graphs.Hnsw.ApproximateNearest(
+                tx.LowLevelTransaction, treeName, numberOfCandidates: 8, queryBytes, 0f);
+
+            Span<long> matches = stackalloc long[8];
+            Span<float> distances = stackalloc float[8];
+            var read = retriever.Fill(matches, distances, filter: null);
+            Assert.True(read >= 1);
+            Assert.Equal(5L, matches[0]);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void LegacyVersionOptionsYieldLegacyKernel()
+    {
+        // Construct an Options struct pinned to the InitialVersion on-disk layout and verify
+        // the kernel dispatcher selects the norm-recomputing path. Locks the version gate so
+        // an accidental bump cannot silently break indexes written under that layout.
+        var legacyOptions = new global::Voron.Data.Graphs.Hnsw.Options
+        {
+            Version = global::Voron.Global.Constants.Graphs.HnswVersion.InitialVersion,
+            SimilarityMethod = global::Voron.Data.Graphs.Hnsw.SimilarityMethod.CosineSimilaritySingles,
+            VectorSizeBytes = 64,
+        };
+        var newOptions = legacyOptions;
+        newOptions.Version = global::Voron.Global.Constants.Graphs.HnswVersion.SinglesWithL2Norm;
+        newOptions.VectorSizeBytes = 68;
+
+        unsafe
+        {
+            var legacyKernel = global::Voron.Data.Graphs.Hnsw.GetDistanceKernel(in legacyOptions);
+            var newKernel = global::Voron.Data.Graphs.Hnsw.GetDistanceKernel(in newOptions);
+
+            // Evaluate each kernel on payloads sized to match its expected on-disk layout. The
+            // legacy kernel consumes 64 bytes of raw floats; the new kernel consumes 68 bytes
+            // (16 unit floats + trailing norm). Confirming each kernel accepts only its own
+            // layout proves the dispatcher selects different code paths.
+            var rng = new Random(11);
+            var a = RandomFloats(rng, 16, scale: 1.0f);
+            var b = RandomFloats(rng, 16, scale: 1.0f);
+            var aRaw = MemoryMarshal.AsBytes(a.AsSpan());
+            var bRaw = MemoryMarshal.AsBytes(b.AsSpan());
+            var legacyVal = legacyKernel(aRaw, bRaw);
+            Assert.False(float.IsNaN(legacyVal));
+
+            var aAtRest = new byte[Hnsw.TensorSizeBytes<float>(16)];
+            var bAtRest = new byte[Hnsw.TensorSizeBytes<float>(16)];
+            Hnsw.WriteNormalizedTensor(a, aAtRest);
+            Hnsw.WriteNormalizedTensor(b, bAtRest);
+            var newVal = newKernel(aAtRest, bAtRest);
+            Assert.False(float.IsNaN(newVal));
+            // Mathematically equivalent, so the magnitudes must agree to float tolerance.
+            Assert.InRange(newVal - legacyVal, -1e-5f, 1e-5f);
+        }
+    }
+
+    private static float[] RandomFloats(Random rng, int dims, float scale)
+    {
+        var v = new float[dims];
+        for (int i = 0; i < dims; i++)
+            v[i] = (float)((rng.NextDouble() * 2 - 1) * scale);
+        return v;
+    }
+
+    private static float[] FilledVector(int dims, float value)
+    {
+        var v = new float[dims];
+        for (int i = 0; i < dims; i++)
+            v[i] = value + 0.001f * i;
+        return v;
+    }
+}

--- a/test/SlowTests/Voron/Graphs/HnswSearch.cs
+++ b/test/SlowTests/Voron/Graphs/HnswSearch.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using FastTests.Voron;
+using FastTests.Voron.Graphs;
 using Sparrow.Server.Collections;
 using Tests.Infrastructure;
 using Voron;


### PR DESCRIPTION
## Summary

Stacked on top of #4 (RavenDB-26421). Three commits that further reduce HNSW query-path cost on the f32-cosine hot path.

### 1. `c39e58` — Cache per-vector L2 norm

Pre-normalize f32 vectors on write and store the original L2 norm in trailing bytes. Query-time cosine becomes a single dot product (`cos(a,b) = a·b` for unit vectors), eliminating two square roots per distance call.

Normalization is owned by `Hnsw.Registration.Register`, which keeps a reusable scratch buffer allocated once per Registration and converts raw-sized inputs into storage form on the fly. Corax's `IndexEntryBuilder.WriteVector` and Voron-layer callers (tests, benchmarks) all go through the same entry point. Query-side auto-normalizes via `Hnsw.NormalizedLayout.TryNormalizeQueryVector`.

### 2. `a950b6` — Vector512-shaped FMA DotProduct

New `Sparrow.Server.Tensors.Functions.DotProduct` kernel. Vector512-shaped but JIT-splittable into two Vector256 FMA streams on AVX2-only hardware (4 parallel ymm chains with `Arithmetics.MultiplyAddEstimate`, within the 16-ymm register budget). Replaces `TensorPrimitives.Dot`, whose `Aggregate<Multiply,Add>` path emits single-accumulator serial mul+add with no FMA.

### 3. `3ed381` — State-machine searcher + hot-path inlining

`IHnswSearcher.Search()` returning `IEnumerable<bool>` compiled to a heap-allocated state-machine class per query (`CORINFO_HELP_NEWSFAST` + 8 heap-field reloads in MoveNext + 65 register/stack spills). Replaced with explicit `bool MoveNextBatch()` on the interface. Nearest/Exact/Empty searchers rewritten as state machines — zero iterator-class allocation per query.

`QueryDistance` and `ResolveEdgeIndexes` split into `AggressiveInlining` fast-path wrappers plus `NoInlining` cold-path helpers (`QueryDistanceMiss`, `ResolveEdgeIndexesSlow`) so the JIT inlines just the cache-hit branch into the search loop. `GetNodeByIndex` marked `AggressiveInlining`.

Disasm (FullOpts, `NearestSearcher.MoveNextBatch`) confirms: zero `NEWSFAST`, fast paths inlined, only cold helpers appear as calls.

## Benchmark results

End-to-end Corax-level QPS, DBpedia-openai3 1536d, N=25k, NQ=200, k=10, M=16, efC=64. R@10 preserved at 98.4–100.0 % on every row.

| Mode              | ef  | BASELINE | PARENT (#4) | **PR** | vs BASE | vs PARENT |
|-------------------|-----|---------:|------------:|-------:|--------:|----------:|
| Single (fresh IS) |  64 |      419 |         392 |    407 |   −2.9% |     +3.8% |
| SharedIS          |  64 |      601 |         585 |    791 |  +31.6% |    +35.2% |
| MultiVector       |  64 |      545 |         816 |   1048 |  +92.3% |    +28.4% |
| Single (fresh IS) | 512 |      147 |         161 |    164 |  +11.6% |     +1.9% |
| SharedIS          | 512 |      125 |         187 |    206 |  +64.8% |    +10.2% |
| MultiVector       | 512 |      127 |         285 |    310 | +144.1% |     +8.8% |

`Concurrent x8` omitted from the table: the one-shot run had ~30% variance driven by JIT / page-cache warm-up in the very short (≤0.2 s) phase. A steady-state 10 s concurrent profile (3 iterations each) confirms BASELINE ≈ PR ≈ 2260 QPS (within 1 %); no regression.

Baseline = commit before RavenDB-26405 (no HNSW optimizations). PARENT (#4) includes NodeCache, neighbor prefetch, and cached edge indexes.

## Test plan

- [x] `dotnet test test/FastTests --filter "Category=Voron"` (HNSW tests)
- [x] `dotnet test test/FastTests --filter "Category=Corax"` (vector-search tests)
- [x] Recall parity — `bench/corax-vector-qps` reports 98.4–100 % R@10 across all modes and ef values.