### PR TITLE
RavenDB-26536 HNSW vector search: state-machine searcher + incremental commit application

### DIFF
--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -85,6 +85,23 @@ namespace Corax.Indexing
         private PostingList _largePostingListSet;
         public int? MaximumConcurrentBatchesForHnswAcceleration;
 
+        /// <summary>
+        /// Per-field set of node ids whose container record was rewritten by the just-finished
+        /// vector commit. Populated as each <see cref="Hnsw.Registration.Commit"/> completes and
+        /// drained by the post-commit hook via <see cref="DrainDirtyVectorSets"/>; the registration
+        /// itself is cleared on field reset, so this dictionary is the only surviving handle to
+        /// the dirty set after <see cref="ResetWriter"/> runs.
+        /// </summary>
+        private Dictionary<Slice, HashSet<long>> _dirtyVectorSets;
+
+        /// <summary>
+        /// Per-field set of node ids that the just-finished commit rewrote in the underlying
+        /// HNSW container. Read by <c>CoraxIndexPersistence.RecreateSearcher</c> to apply
+        /// incremental updates to the long-lived <c>HnswIndexCache</c>; null when no vector
+        /// field saw any modification.
+        /// </summary>
+        public Dictionary<Slice, HashSet<long>> DirtyVectorSets => _dirtyVectorSets;
+
         private long _compactTreeDictionaryId = Constants.IndexSearcher.InvalidId;
         private EntriesToTermsTracker _entriesToTermsTracker;
 
@@ -1094,6 +1111,15 @@ namespace Corax.Indexing
                     if (MaximumConcurrentBatchesForHnswAcceleration != null)
                         indexedField.VectorIndexer.MaxConcurrentBatches = MaximumConcurrentBatchesForHnswAcceleration.Value;
                     indexedField.VectorIndexer.Commit(token);
+
+                    // Snapshot DirtyNodeIds before ResetWriter clears the field's VectorIndexer.
+                    // The post-commit hook (CoraxIndexPersistence.RecreateSearcher) consumes this
+                    // to apply incremental updates against the long-lived HnswIndexCache.
+                    if (indexedField.VectorIndexer.DirtyNodeIds.Count > 0)
+                    {
+                        _dirtyVectorSets ??= new Dictionary<Slice, HashSet<long>>(SliceComparer.Instance);
+                        _dirtyVectorSets[indexedField.Name] = indexedField.VectorIndexer.DirtyNodeIds;
+                    }
                 }
 
                 if (indexedField.Textual.Count == 0)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
@@ -22,6 +22,7 @@ using Voron.Data.CompactTrees;
 using Voron.Data.Graphs;
 using Voron.Impl;
 using Constants = Raven.Client.Constants;
+using IndexWriter = Corax.Indexing.IndexWriter;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Corax;
 
@@ -31,9 +32,11 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
     private readonly RavenLogger _logger;
     private readonly CoraxDocumentConverterBase _converter;
 
+    private Dictionary<Slice, HnswIndexCache> _hnswCaches;
     private IndexTransactionCache _currentCache;
     private StorageEnvironment _environment;
     private Action<LowLevelTransaction> _newTransactionCreatedHandler;
+    internal IndexWriter ActiveWriter;
 
     public CoraxIndexPersistence(Index index, IIndexReadOperationFactory indexReadOperationFactory) : base(index, indexReadOperationFactory)
     {
@@ -122,6 +125,12 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
             _environment = null;
         }
         _converter?.Dispose();
+        if (_hnswCaches != null)
+        {
+            foreach (var kv in _hnswCaches)
+                kv.Value.Dispose();
+            _hnswCaches = null;
+        }
     }
 
     public override bool RequireOnBeforeExecuteIndexing()
@@ -199,7 +208,8 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
     public override void Initialize(StorageEnvironment environment)
     {
         using (var roTx = environment.ReadTransaction())
-            _currentCache = BuildVectorCacheSnapshot(roTx);
+            WarmInitialCaches(roTx);
+        _currentCache = BuildSnapshotWrapper();
 
         _environment = environment;
         _newTransactionCreatedHandler = tx => tx.ImmutableExternalState = Volatile.Read(ref _currentCache);
@@ -208,41 +218,55 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
 
     public override void PublishIndexCacheToNewTransactions(IndexTransactionCache transactionCache)
     {
-        // Corax builds and publishes its cache in RecreateSearcher rather than here.
-        // BuildStreamCacheAfterTx returns null, so this method is always invoked with null.
     }
 
     internal override IndexTransactionCache BuildStreamCacheAfterTx(Transaction tx)
     {
-        // The actual vector cache build runs in RecreateSearcher, which is invoked from the
-        // post-commit hook — only after the commit is durable.
         return null;
     }
 
     internal override void RecreateSearcher(Transaction asOfTx)
     {
-        // Invoked from AfterCommitWhenNewTransactionsPrevented: at this point the commit is
-        // durable and no new read transaction can be created until this method returns. Building
-        // and assigning _currentCache here guarantees that the published cache reflects a state
-        // that is already visible on disk, and that every read transaction created afterwards
-        // captures it atomically via the NewTransactionCreated subscription in Initialize.
-        var newCache = BuildVectorCacheSnapshot(asOfTx);
-        if (newCache != null)
-            _currentCache = newCache;
+        var writer = ActiveWriter;
+        if (writer == null || _hnswCaches == null)
+            return;
+
+        if (GetMaxNodesForVectorCache() <= 0)
+        {
+            // Cache disabled at runtime (CacheSizeInMb set to 0): stop publishing the caches and drop
+            // our references so new read transactions resolve from disk and a later re-enable rebuilds
+            // from scratch rather than serving entries that missed the commits made while disabled.
+            // In-flight readers keep their captured snapshot; the dropped instances release their native
+            // memory via finalization once those transactions complete.
+            Volatile.Write(ref _currentCache, null);
+            Volatile.Write(ref _hnswCaches, null);
+            return;
+        }
+
+        var dirty = writer.DirtyVectorSets;
+        if (dirty == null)
+            return;
+
+        var llt = asOfTx.LowLevelTransaction;
+        foreach (var kv in dirty)
+        {
+            if (_hnswCaches.TryGetValue(kv.Key, out var cache) == false)
+                continue;
+            cache.ApplyCommit(llt, kv.Key, kv.Value);
+        }
     }
 
-    private IndexTransactionCache BuildVectorCacheSnapshot(Transaction tx)
+    private void WarmInitialCaches(Transaction tx)
     {
         var mapping = _converter?.GetKnownFieldsForQuerying();
         if (mapping is null)
-            return null;
+            return;
 
         var maxNodes = GetMaxNodesForVectorCache();
         if (maxNodes <= 0)
-            return null;
+            return;
 
         var llt = tx.LowLevelTransaction;
-        Dictionary<Slice, HnswIndexCache> vectorCaches = null;
         foreach (var field in mapping)
         {
             if (field.VectorOptions is null)
@@ -250,16 +274,21 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
             var cache = HnswIndexCache.WarmFromScratch(llt, field.FieldName, maxNodes);
             if (cache is null)
                 continue;
-            vectorCaches ??= new Dictionary<Slice, HnswIndexCache>(SliceComparer.Instance);
+            _hnswCaches ??= new Dictionary<Slice, HnswIndexCache>(SliceComparer.Instance);
             // FieldName is allocated against _converter's persistent scope; _converter is
-            // disposed only when this CoraxIndexPersistence is disposed, which outlives any cache
-            // reachable from _currentCache or an open read tx's ImmutableExternalState.
+            // disposed only when this CoraxIndexPersistence is disposed, which outlives any
+            // open read tx's ImmutableExternalState reference.
             Debug.Assert(field.FieldName.HasValue && field.FieldName.Size > 0,
                 "Vector field name must be allocated and non-empty for cache keying");
-            vectorCaches[field.FieldName] = cache;
+            _hnswCaches[field.FieldName] = cache;
         }
+    }
 
-        return vectorCaches is null ? null : new IndexTransactionCache { VectorNodeCaches = vectorCaches };
+    private IndexTransactionCache BuildSnapshotWrapper()
+    {
+        return _hnswCaches is null
+            ? null
+            : new IndexTransactionCache { VectorNodeCaches = _hnswCaches };
     }
 
     internal override void RecreateSuggestionsSearchers(Transaction asOfTx)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 {
     public class CoraxIndexWriteOperation : IndexWriteOperationBase
     {
-        
+
         public const int MaximumPersistedCapacityOfCoraxWriter = 512;
         private readonly IndexWriter _indexWriter;
         private readonly CoraxDocumentConverterBase _converter;
@@ -32,10 +32,12 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
         private IndexFieldsMapping _dynamicFields;
         private readonly CurrentIndexingScope _indexingScope;
         private readonly ByteStringContext _allocator;
+        private readonly CoraxIndexPersistence _persistence;
 
         public CoraxIndexWriteOperation(Index index, Transaction writeTransaction, CoraxDocumentConverterBase converter, RavenLogger logger) : base(index, logger)
         {
             _converter = converter;
+            _persistence = index.IndexPersistence as CoraxIndexPersistence;
             var knownFields = _converter.GetKnownFieldsForWriter();
             _indexingScope = CurrentIndexingScope.Current;
             if (_indexingScope != null)
@@ -82,11 +84,25 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
         
         public override void Commit(IndexingStatsScope stats, CancellationToken token)
         {
-            if (_indexWriter != null)
+            if (_indexWriter == null)
+                return;
+
+            using (var commitStats = stats.For(IndexingOperation.Corax.Commit))
             {
-                using (var commitStats = stats.For(IndexingOperation.Corax.Commit))
+                // Publish the writer to the persistence so RecreateSearcher (which fires from
+                // the LLT post-commit hook inside _indexWriter.Commit) can read DirtyVectorSets
+                // and mutate the long-lived HnswIndexCache instances. Cleared in finally so the
+                // back-reference never leaks beyond a single commit even if the commit throws.
+                if (_persistence != null)
+                    _persistence.ActiveWriter = _indexWriter;
+                try
                 {
                     _indexWriter.Commit(new CoraxIndexingStats(commitStats), token);
+                }
+                finally
+                {
+                    if (_persistence != null)
+                        _persistence.ActiveWriter = null;
                 }
             }
         }

--- a/src/Voron/Data/Graphs/Hnsw.Debug.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Debug.cs
@@ -158,8 +158,7 @@ table, th, td {
             var edges = new ContextBoundNativeList<int>(llt.Allocator, 16);
             searchState.SearchNearestAcrossLevels(vector, -1, searchState.Options.MaxLevel,  ref path);
             using var search = searchState.NearestSearch(path[0], new Memory<byte>(vector.ToArray()), 0, 8, edges, SearchState.NearestEdgesFlags.StartingPointAsEdge, false);
-            using var it = search.Search().GetEnumerator();
-            it.MoveNext();
+            search.MoveNextBatch();
             search.TryGetCurrentCandidates(out edges);
             
             

--- a/src/Voron/Data/Graphs/Hnsw.EmptySearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.EmptySearcher.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using Voron.Util;
 
 namespace Voron.Data.Graphs;
@@ -14,10 +13,7 @@ public partial class Hnsw
             {
             }
 
-            public IEnumerable<bool> Search()
-            {
-                yield break;
-            }
+            public bool MoveNextBatch() => false;
 
             public bool TryGetCurrentCandidates(out ContextBoundNativeList<int> candidates)
             {

--- a/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
@@ -20,6 +20,7 @@ public partial class Hnsw
             private readonly ContextBoundNativeList<long>? _nodesToScan;
             private PriorityQueue<long, float> _pq;
             private long _vectorReadCounter = 0;
+            private bool _initialized;
             
             public ExactSearcher(SearchState searchState, Memory<byte> vector, bool hasFilterMatch, int numberOfCandidates, ContextBoundNativeList<long>? nodesToScan)
             {
@@ -42,7 +43,31 @@ public partial class Hnsw
                 _candidates.Dispose();
             }
 
-            public IEnumerable<bool> Search()
+            public bool MoveNextBatch()
+            {
+                if (_initialized == false)
+                {
+                    Initialize();
+                    _initialized = true;
+                }
+
+                if (_pq.Count == 0)
+                {
+                    _candidates.Count = 0;
+                    return false;
+                }
+
+                _candidates.Count = 0;
+                while (_candidates.Count < NumberOfCandidates && _pq.TryDequeue(out var nodeId, out _))
+                {
+                    _candidates.AddByRefUnsafe() = _searchState.GetNodeIndexById(nodeId);
+                }
+
+                _candidates.Inner.Reverse();
+                return true;
+            }
+
+            private void Initialize()
             {
                 // Reset the visited set for this traversal and record the query vector so the
                 // per-node QueryDistance cache is either reused (same vector) or invalidated
@@ -51,45 +76,32 @@ public partial class Hnsw
                 _searchState.OnQueryVector(_vector);
 
                 _pq = new PriorityQueue<long, float>();
-                Span<byte> vector = _vector.Span;
-                IEnumerable<long> toScan = _nodesToScan.HasValue ? _nodesToScan.Value.Iterate() : AllNodes();
-                foreach (long nodeId in toScan)
+                if (_nodesToScan.HasValue)
                 {
-                    CandidatesProcessed++;
-                    var nodeIndex = _searchState.GetNodeIndexById(nodeId);
-                    if ((_searchState.GetNodeByIndex(nodeIndex).PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone)
-                        continue; // no entries, can skip
-
-                    var distance = _searchState.QueryDistance(_vector.Span, nodeIndex, ref _vectorReadCounter);
-                    if (_pq.Count < NumberOfCandidates || _hasFilterMatch)
-                    {
-                        _pq.Enqueue(nodeId, -distance);
-                    }
-                    else
-                    {
-                        _pq.EnqueueDequeue(nodeId, -distance);
-                    }
+                    foreach (long nodeId in _nodesToScan.Value.Iterate())
+                        ScanNode(nodeId);
                 }
-
-                while (_pq.Count > 0)
+                else
                 {
-                    _candidates.Count = 0;
-                    while (_candidates.Count < NumberOfCandidates && _pq.TryDequeue(out var nodeId, out _))
-                    {
-                        _candidates.AddByRefUnsafe() = _searchState.GetNodeIndexById(nodeId);
-                    }
-
-                    _candidates.Inner.Reverse();
-                    yield return true;
+                    long count = _searchState.Options.CountOfVectors;
+                    for (long nodeId = 1; nodeId <= count; nodeId++)
+                        ScanNode(nodeId);
                 }
+            }
 
-                _candidates.Count = 0;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private void ScanNode(long nodeId)
+            {
+                CandidatesProcessed++;
+                var nodeIndex = _searchState.GetNodeIndexById(nodeId);
+                if ((_searchState.GetNodeByIndex(nodeIndex).PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone)
+                    return;
 
-                IEnumerable<long> AllNodes()
-                {
-                    for (long nodeId = 1; nodeId <= _searchState.Options.CountOfVectors; nodeId++)
-                        yield return nodeId;
-                }
+                var distance = _searchState.QueryDistance(_vector.Span, nodeIndex, ref _vectorReadCounter);
+                if (_pq.Count < NumberOfCandidates || _hasFilterMatch)
+                    _pq.Enqueue(nodeId, -distance);
+                else
+                    _pq.EnqueueDequeue(nodeId, -distance);
             }
 
             public bool TryGetCurrentCandidates(out ContextBoundNativeList<int> candidates)

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -31,6 +31,14 @@ public unsafe partial class Hnsw
             private long _vectorReadCounter = 0;
             private readonly int _startingPointIndex;
             private ContextBoundNativeList<int> _startingPointIndexes;
+
+            // Traversal state carried across MoveNextBatch calls so the caller can consume
+            // one batch at a time. _needsRestart triggers a fresh InitState; _isDone short-circuits
+            // further work once the outer traversal has finished.
+            private float _lowerBound;
+            private int _visitedCounter;
+            private bool _needsRestart = true;
+            private bool _isDone;
             
             public long CandidatesProcessed { get => _vectorReadCounter; }
             public int NumberOfCandidates { get; init; }
@@ -146,53 +154,57 @@ public unsafe partial class Hnsw
                 }
             }
 
-            public IEnumerable<bool> Search()
+            public bool MoveNextBatch()
             {
-                Start:
+                if (_isDone)
+                    return false;
+
                 var candidatesQ = _searchState._candidatesQ;
                 var nearestEdgesQ = _searchState._nearestEdgesQ;
-                var allocator = _searchState.Llt.Allocator;
 
-                Debug.Assert(candidatesQ.Count == 0, "_candidatesQ.Count == 0");
-                Debug.Assert(nearestEdgesQ.Count == 0, "_nearestEdgesQ.Count == 0");
-                InitState(out float lowerBound, out int visitedCounter);
+                if (_needsRestart)
+                {
+                    Debug.Assert(candidatesQ.Count == 0, "_candidatesQ.Count == 0");
+                    Debug.Assert(nearestEdgesQ.Count == 0, "_nearestEdgesQ.Count == 0");
+                    InitState(out _lowerBound, out _visitedCounter);
+                    _needsRestart = false;
+                }
 
                 while (candidatesQ.TryDequeue(out var cur, out var curDistance))
                 {
-                    if (-curDistance < lowerBound &&
+                    if (-curDistance < _lowerBound &&
                         nearestEdgesQ.Count == _internalNumberOfCandidates)
                     {
                         ProcessResults();
-                        // Drain candidatesQ before yielding. Non-filtered queries consume only
-                        // the first batch and never resume the iterator, so without this clear
-                        // the shared SearchState carries far-from-the-old-vector candidates into
-                        // the next query, polluting its priority queue and forcing the search to
-                        // expand 25-30% more nodes than a fresh state would.
+                        // Drain candidatesQ before yielding. Non-filtered queries consume only the
+                        // first batch and never resume; without this clear, a shared SearchState
+                        // (e.g. MultiVectorSearch sub-queries) carries far-from-the-old-vector
+                        // candidates into the next query and pollutes its priority queue. It also
+                        // satisfies InitState's empty-queue precondition on the restart path.
                         candidatesQ.Clear();
-                        yield return true;
-                        // If we need to fetch more, we'll start the query again with a higher NumberOfCandidates.
-                        // The SearchState keeps its state, so traversal through already visited nodes is I/O-free
-                        // because we keep distances in memory from the previous run.
-                        // This method can be greedy enough to traverse the entire graph, so it's the caller's
-                        // responsibility to enforce a stop condition.
-                        goto Start;
+                        // Yield the current batch. Subsequent MoveNextBatch calls re-enter via InitState;
+                        // revisits are I/O-free because per-node distances remain cached in SearchState.
+                        // The caller is responsible for enforcing a stop condition: otherwise the search
+                        // may traverse the entire graph.
+                        _needsRestart = true;
+                        return true;
                     }
 
-                    _searchState.GetNodeByIndex(cur).Visited = visitedCounter;
+                    _searchState.GetNodeByIndex(cur).Visited = _visitedCounter;
                     _searchState.ResolveEdgeIndexes(cur, _level, ref _nodeIds, ref _indexes);
 
                     for (int i = 0; i < _indexes.Count; i++)
                     {
                         var nextIndex = _indexes[i];
                         ref var next = ref _searchState.GetNodeByIndex(nextIndex);
-                        if (next.Visited == visitedCounter)
+                        if (next.Visited == _visitedCounter)
                             continue; // already checked
-                        next.Visited = visitedCounter;
+                        next.Visited = _visitedCounter;
 
                         // Prefetch the next unvisited neighbor's vector data to overlap
                         // cache-miss latency with the current distance computation.
                         // SimilarityCalc is ~65% of query time, ~80% of which is data loading.
-                        PrefetchNextNeighborVector(i + 1, visitedCounter);
+                        PrefetchNextNeighborVector(i + 1, _visitedCounter);
 
                         var isDeleted = (next.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone
                                         || (_hasFilterMatch && _alreadyReturnedEdges.Contains(nextIndex));
@@ -207,7 +219,7 @@ public unsafe partial class Hnsw
                                 nearestEdgesQ.Enqueue(nextIndex, nextDist);
                             }
                         }
-                        else if (lowerBound < nextDist)
+                        else if (_lowerBound < nextDist)
                         {
                             candidatesQ.Enqueue(nextIndex, -nextDist);
 
@@ -222,14 +234,15 @@ public unsafe partial class Hnsw
                         }
 
                         Debug.Assert(candidatesQ.Count > 0);
-                        nearestEdgesQ.TryPeek(out _, out lowerBound);
+                        nearestEdgesQ.TryPeek(out _, out _lowerBound);
                     }
                 }
 
                 // Nothing more to visit. Move the current results into the candidates list and finish.
                 ProcessResults();
                 candidatesQ.Clear();
-                yield return _candidates.Count > 0;
+                _isDone = true;
+                return _candidates.Count > 0;
             }
 
             public bool TryGetCurrentCandidates(out ContextBoundNativeList<int> candidates)
@@ -242,6 +255,9 @@ public unsafe partial class Hnsw
             {
                 Reset();
                 _internalNumberOfCandidates += GetPrefetchExtendSize(_internalNumberOfCandidates);
+                // The next MoveNextBatch call will InitState from the starting points again.
+                _needsRestart = true;
+                _isDone = false;
             }
 
             // Reset the NearestSearcher state; however, it does not clear the data already stored inside SearchState.

--- a/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
+++ b/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Sparrow;
-using Sparrow.Server;
 using Sparrow.Server.Collections;
 using Voron.Data.Containers;
 using Voron.Data.PostingLists;
@@ -30,7 +28,6 @@ public partial class Hnsw
         private bool _foundCandidateInCurrentSmallPostingList;
         private readonly IHnswSearcher _vectorsSearcher;
         private readonly Memory<byte> _vector;
-        private IEnumerator<bool> _resultsEnumerator;
         // When the searchState-based entry points allocate a normalized copy of the query
         // vector they hand the scope here so Dispose releases it alongside the retriever's
         // other per-query state.
@@ -59,8 +56,7 @@ public partial class Hnsw
             _postingListResults = new(_searchState.Llt.Allocator);
             _pforDecoder = new(searchState.Llt.Allocator);
             _maximumDistance = searchState.MinimumSimilarityToDistance(minimumSimilarity);
-            _resultsEnumerator = _vectorsSearcher.Search().GetEnumerator();
-            _resultsEnumerator.MoveNext(); //read first batch
+            _vectorsSearcher.MoveNextBatch(); // prime the first batch
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -184,13 +180,10 @@ public partial class Hnsw
                     {
                         break;
                     }
-                    
-                    if (_resultsEnumerator.MoveNext() == false)
-                    {
-                        _resultsEnumerator = _vectorsSearcher.Search().GetEnumerator();    
-                        _resultsEnumerator.MoveNext();
-                    }
-                    
+
+                    // Pull the next batch into _vectorsSearcher. An empty batch is valid — TryGetCurrentCandidates below handles it.
+                    _vectorsSearcher.MoveNextBatch();
+
                     // If we fetch more than once, we've no guarantee that the whole set of results are sorted by distances.
                     // We could explore not previously seen nodes that are closer to the query vector than the ones we've already seen.
                     IsSortedByDistance = false;
@@ -317,7 +310,6 @@ public partial class Hnsw
         {
             _postingListResults.Dispose();
             _pforDecoder.Dispose();
-            _resultsEnumerator?.Dispose();
             _vectorsSearcher?.Dispose();
             _queryVectorScope?.Dispose();
             if (_ownsSearchState)

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -805,6 +805,14 @@ public unsafe partial class Hnsw
     {
         public bool IsCommited { get; private set; }
         private readonly Dictionary<ByteString, (ByteString Key, int NodeIndex, NativeList<long> PostingList)> _vectorHashCache = new(ByteStringContentComparer.Instance);
+
+        /// <summary>
+        /// Node ids whose persisted record was written or rewritten during this commit. The
+        /// post-commit cache update (HnswIndexCache.ApplyCommit) consumes this set to bring the
+        /// in-memory cache forward without re-running BFS from the entry point. Populated by
+        /// the persistence loop in Commit.
+        /// </summary>
+        public HashSet<long> DirtyNodeIds { get; } = new();
         private readonly Lookup<Int64LookupKey> _nodesByVectorId;
         private SearchState _searchState;
         public Random Random;
@@ -1073,6 +1081,7 @@ public unsafe partial class Hnsw
             for (int i = 0; i < nodes.Length; i++)
             {
                 PersistNode(ref nodes[i], ref byteBuffer);
+                DirtyNodeIds.Add(nodes[i].NodeId);
             }
 
             // flush the local modifications
@@ -1280,13 +1289,13 @@ public unsafe partial class Hnsw
      where TEnumerator : IEnumerator<long>
     {
         var searchState = new SearchState(llt, name, ref vector);
+        if (searchState.Options.CountOfVectors == 0)
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity);
+
         var startingPointsIndexes = new ContextBoundNativeList<int>(llt.Allocator);
         var candidates = new ContextBoundNativeList<int>(llt.Allocator);
         candidates.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
 
-        if (searchState.Options.CountOfVectors == 0)
-            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity);
-        
         searchState.SearchFilteredNearest(ref startingPointsIndexes, nodesToProbe, numberOfCandidates, 16);
         candidates.Clear();
         var nearestEdgesSearch = searchState.NearestSearch(startingPointsIndexes, vector, 0, numberOfCandidates, candidates,
@@ -1297,12 +1306,12 @@ public unsafe partial class Hnsw
     public static VectorSearchRetriever ApproximateNearest(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch = false)
     {
         var searchState = new SearchState(llt, name, ref vector);
+        if (searchState.Options.CountOfVectors == 0)
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity);
+
         var nearestNodesByLevel = new ContextBoundNativeList<int>(llt.Allocator);
         nearestNodesByLevel.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
 
-        if (searchState.Options.CountOfVectors == 0)
-            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity);
-        
         searchState.SearchNearestAcrossLevels(vector.Span, -1, searchState.Options.MaxLevel, ref nearestNodesByLevel);
         var nearest = nearestNodesByLevel[0];
         nearestNodesByLevel.Clear();
@@ -1326,11 +1335,11 @@ public unsafe partial class Hnsw
         // and the upper-level descent latches onto the wrong starting point.
         searchState.OnQueryVector(vector);
 
-        var nearestNodesByLevel = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
-        nearestNodesByLevel.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
-
         if (searchState.Options.CountOfVectors == 0)
             return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
+
+        var nearestNodesByLevel = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
+        nearestNodesByLevel.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
 
         searchState.SearchNearestAcrossLevels(vector.Span, -1, searchState.Options.MaxLevel, ref nearestNodesByLevel);
         var nearest = nearestNodesByLevel[0];
@@ -1362,12 +1371,12 @@ public unsafe partial class Hnsw
         TryNormalizeQueryVector(searchState.Options, searchState.Llt.Allocator, ref vector, out var queryVectorScope);
         searchState.OnQueryVector(vector);
 
+        if (searchState.Options.CountOfVectors == 0)
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
+
         var startingPointsIndexes = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
         var candidates = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
         candidates.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
-
-        if (searchState.Options.CountOfVectors == 0)
-            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
 
         searchState.SearchFilteredNearest(ref startingPointsIndexes, nodesToProbe, numberOfCandidates, 16);
         candidates.Clear();

--- a/src/Voron/Data/Graphs/IHNSWSearcher.cs
+++ b/src/Voron/Data/Graphs/IHNSWSearcher.cs
@@ -1,15 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using Voron.Util;
 
 namespace Voron.Data.Graphs;
 
 public interface IHnswSearcher : IDisposable
 {
-    // Find nodes accepted by the query vector.
-    // Guarantee: always returns previously unseen nodes.
-    // To retrieve the accepted nodes, call TryGetCurrentCandidates.
-    public IEnumerable<bool> Search();
+    // Advances the search until the next batch of candidates is ready, then yields control to the caller so it can drain them via TryGetCurrentCandidates. Batches contain only previously unseen nodes. Returns true while batches remain, false once the search is exhausted.
+    public bool MoveNextBatch();
 
     // Retrieve IDs of nodes from the current search batch.
     // Guarantee: always returns previously unseen nodes.


### PR DESCRIPTION
## Summary

Refactor the HNSW search hot path. Two changes that share the same surface (`NearestSearcher` + commit pipeline) and depend on the foundation cache landed in RavenDB-26405.

- **State-machine searcher.** Replace the iterator-based `NearestSearcher` with an explicit state machine. Inlines hot query ops, removes per-iteration enumerator allocation, and makes the priority-queue handover between sub-queries explicit so a shared `SearchState` can drive multi-vector search safely.
- **Incremental commit application via DirtyNodeIds.** Apply HNSW commits incrementally instead of rebuilding the per-index cache from scratch on every commit. Writers track dirty node ids; readers materialize only those nodes into the cache delta.

Pure refactors. No on-disk format change, no public API change.

Stacked on **#5 RavenDB-26423** (FMA tip).

## Test plan
- [ ] `dotnet test test/FastTests --filter "Category=Voron|Category=Vector"`
- [ ] `dotnet test test/SlowTests --filter "FullyQualifiedName~Hnsw|FullyQualifiedName~VectorSearch"`
- [ ] HNSW search QPS bench (no regression vs RavenDB-26423 tip)